### PR TITLE
chore(deps): bump Pygments, GitPython, and mkdocs-rss-plugin

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -340,22 +340,22 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.45"
+version = "3.1.50"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77"},
-    {file = "gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c"},
+    {file = "gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"},
+    {file = "gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc"},
 ]
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [package.extras]
-doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "h11"
@@ -738,27 +738,28 @@ typing-inspect = {version = ">=0.8.0,<0.9.0", markers = "python_version >= \"3.6
 
 [[package]]
 name = "mkdocs-rss-plugin"
-version = "1.17.4"
-description = "MkDocs plugin which generates a static RSS feed using git log and page.meta."
+version = "1.19.0"
+description = "MkDocs plugin to generate RSS and JSON feeds using Mkdocs site configuration, git log and Mkdocs pages'meta."
 optional = false
-python-versions = "<4,>=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mkdocs_rss_plugin-1.17.4-py2.py3-none-any.whl", hash = "sha256:c05fdb5a63fdf396f8d05169e45a08388abc3eb6f55ca4d23682039aad0cce50"},
-    {file = "mkdocs_rss_plugin-1.17.4.tar.gz", hash = "sha256:cfd42d250cbf7a73b006cbe291eedb29d32d4d8bf803f7da0e7a98bedcda2ac3"},
+    {file = "mkdocs_rss_plugin-1.19.0-py3-none-any.whl", hash = "sha256:5fdaffdee96745011c7c7786ed52b42a2d751f3aad84c188ffbedeb5a6e2994a"},
+    {file = "mkdocs_rss_plugin-1.19.0.tar.gz", hash = "sha256:0b9b7f14688393e5bd7d26a6dc14dfd2b228a8cdfe5b598a6677589b2159d957"},
 ]
 
 [package.dependencies]
-cachecontrol = {version = ">=0.14,<1", extras = ["filecache"]}
-GitPython = ">=3.1.43,<3.2"
-mkdocs = ">=1.6.1,<2"
-requests = ">=2.31,<3"
-tzdata = {version = "==2024.*", markers = "python_version >= \"3.9\" and sys_platform == \"win32\""}
+CacheControl = {version = ">=0.14.3,<1", extras = ["filecache"]}
+GitPython = ">=3.1.45,<3.2"
+mkdocs = "1.6.1"
+properdocs = ">=1.6.5,<2"
+requests = ">=2.32.5,<3"
+tzdata = {version = ">=2024,<2026", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-dev = ["black", "flake8 (>=7.1,<8)", "flake8-bugbear (>=24.10)", "flake8-builtins (>=2.5)", "flake8-eradicate (>=1.5)", "flake8-isort (>=6.1.1)", "pre-commit (>=3.7,<5)"]
-doc = ["mkdocs-git-committers-plugin-2 (>=2.4.1,<2.6)", "mkdocs-git-revision-date-localized-plugin (>=1.3,<1.5)", "mkdocs-material[imaging] (>=9.5.47,<10)", "mkdocs-minify-plugin (>=0.8,<0.9)", "mkdocstrings-python (>=1.16.2,<1.19)", "termynal (>=0.12.2,<0.14)"]
-test = ["feedparser (>=6.0.11,<6.1)", "jsonfeed-util (>=1.2,<2)", "mkdocs-material[imaging] (>=9.5.47)", "pytest-cov (>=6,<8)", "validator-collection (>=1.5,<1.6)"]
+dev = ["Flake8-pyproject (>=1.2.3)", "black (>=25.9)", "flake8 (>=7.1)", "flake8-bugbear (>=24.10)", "flake8-builtins (>=2.5)", "flake8-eradicate (>=1.5)", "flake8-isort (>=6.1.1)", "pre-commit (>=4,<5)"]
+docs = ["mkdocs-git-committers-plugin-2 (>=2.4.1,<2.6)", "mkdocs-git-revision-date-localized-plugin (>=1.3,<1.6)", "mkdocs-material[imaging] (>=9.7,<9.8)", "mkdocs-minify-plugin (>=0.8,<0.9)", "mkdocstrings-python (>=1.16.2,<2.1)", "termynal (>=0.12.2,<0.15)"]
+test = ["feedparser (>=6.0.12,<6.1)", "jsonfeed-util (>=1.2,<2)", "mkdocs-material[imaging] (>=9.7,<9.8)", "mkdocs-materialx[imaging] (>=10.1.3,<11)", "pytest-cov (>=6.9.1,<8)", "validator-collection (>=1.5,<1.6)"]
 
 [[package]]
 name = "msgpack"
@@ -914,15 +915,44 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-
 type = ["mypy (>=1.18.2)"]
 
 [[package]]
-name = "pygments"
-version = "2.19.2"
-description = "Pygments is a syntax highlighting package written in Python."
+name = "properdocs"
+version = "1.6.7"
+description = "Project documentation with Markdown."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd"},
+    {file = "properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
+ghp-import = ">=1.0"
+jinja2 = ">=2.11.1"
+markdown = ">=3.3.6"
+markupsafe = ">=2.0.1"
+packaging = ">=20.5"
+pathspec = ">=0.11.1"
+platformdirs = ">=2.2.0"
+pyyaml = ">=5.1"
+pyyaml-env-tag = ">=0.1"
+watchdog = ">=2.0"
+
+[package.extras]
+i18n = ["babel (>=2.9.0)"]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->

Dependabot was unable to automatically resolve these alerts because the affected packages are transitive dependencies.

### Updated dependencies
#### Pygments
- Update from 2.19.2 → 2.20
- Resolves the Dependabot alert for affected versions < 2.20.
- https://github.com/acrlabs/www/security/dependabot/25

#### GitPython
- Update from 3.1.45 → 3.1.50
- Resolves the Dependabot alerts for affected versions <= 3.1.47.
   - https://github.com/acrlabs/www/security/dependabot/26
   - https://github.com/acrlabs/www/security/dependabot/27
   - https://github.com/acrlabs/www/security/dependabot/28
   - https://github.com/acrlabs/www/security/dependabot/29
   - https://github.com/acrlabs/www/security/dependabot/30

#### mkdocs-rss-plugin
- Update from 1.17.4 → 1.19.0
- Updated while refreshing transitive dependencies. Although the newer release does not increase its minimum required GitPython version, it brings the plugin itself up to date.

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
